### PR TITLE
Expl. connect tests to real tty; bump to 0.0.15

### DIFF
--- a/include/ut/ut.h
+++ b/include/ut/ut.h
@@ -28,7 +28,7 @@
 #include <sys/ioctl.h>  // ioctl
 #endif
 
-#define UT_VERSION "0.0.14"
+#define UT_VERSION "0.0.15"
 
 #define CTOR __attribute((constructor))
 #define TRY() (setjmp(UT.jmpbuf) == 0)

--- a/tools/watch.sh
+++ b/tools/watch.sh
@@ -104,7 +104,7 @@ inotifywait -q --recursive --monitor --format "%e %w%f" \
 --exclude '#' \
 --event ${evlist} ${UT_PROJ} ${UTROOT} \
 | while read changed; do
-    echo "$changed" | grep "$RE" 2>&1 > /dev/null && trytests "$changed"
+    echo "$changed" | grep "$RE" 2>&1 > /dev/null && trytests "$changed" </dev/tty >/dev/tty 2>&1
 done
 
 fi


### PR DESCRIPTION
watch.sh: restore test runner I/O to real TTY

Without this, test processes (and gdb inside them) inherit stdin/out from the inotifywait pipe, leading to "input not from terminal" and stray "MODIFY ..." lines being parsed as gdb commands.

Fix by explicitly attaching trytests() to /dev/tty.